### PR TITLE
add centralization risk findings

### DIFF
--- a/src/issues/M/centralizationRisk.ts
+++ b/src/issues/M/centralizationRisk.ts
@@ -5,7 +5,7 @@ const issue: RegexIssue = {
   type: IssueTypes.M,
   title: 'Centralization Risk for trusted owners',
   impact: 'Contracts have owners with privileged rights to perform admin tasks and need to be trusted to not perform malicious updates or drain funds.',
-  regex: /( onlyOwner )|( onlyRole\()|(Owned)!?([(, ])|(Ownable)!?([(, ])|(Ownable2Step)!?([(, ])|(AccessControl)!?([(, ])|(AccessControlCrossChain)!?([(, ])|(AccessControlEnumerable)!?([(, ])/g,
+  regex: /( onlyOwner )|( onlyRole\()|( requiresAuth )|(Owned)!?([(, ])|(Ownable)!?([(, ])|(Ownable2Step)!?([(, ])|(AccessControl)!?([(, ])|(AccessControlCrossChain)!?([(, ])|(AccessControlEnumerable)!?([(, ])|(Auth)!?([(, ])|(RolesAuthority)!?([(, ])|(MultiRolesAuthority)!?([(, ])/g,
 };
 
 export default issue;

--- a/src/issues/M/centralizationRisk.ts
+++ b/src/issues/M/centralizationRisk.ts
@@ -1,0 +1,11 @@
+import { IssueTypes, RegexIssue } from '../../types';
+
+const issue: RegexIssue = {
+  regexOrAST: 'Regex',
+  type: IssueTypes.M,
+  title: 'Centralization Risk for trusted owners',
+  impact: 'Contracts have owners with privileged rights to perform admin tasks and need to be trusted to not perform malicious updates or drain funds.',
+  regex: /( onlyOwner )|( onlyRole\()|(Owned)!?([(, ])|(Ownable)!?([(, ])|(Ownable2Step)!?([(, ])|(AccessControl)!?([(, ])|(AccessControlCrossChain)!?([(, ])|(AccessControlEnumerable)!?([(, ])/g,
+};
+
+export default issue;


### PR DESCRIPTION
aviggiano suggested to Including "Centralization risk" as part of c4udit.

Thread: https://discord.com/channels/810916927919620096/1054022325563052073

This PR will create an automated medium-risk finding with:

**Title**: Centralization Risk for trusted owners
**Impact**: Contracts have owners with privileged rights to perform admin tasks and need to be trusted to not perform malicious updates or drain funds.


It will search for functions with the modifier **onlyOwner**, **onlyRole** or **requiresAuth**. 
Contracts extensions from solmate and openzeppelin with **Ownable**, **Ownable2Step**, **AccessControl**, **AccessControlCrossChain**, **AccessControlEnumerable**, **Owned**, **RolesAuthority**, **MultiRolesAuthority**, **Auth** will also be marked in the findings.