### PR TITLE
avoid spurious inequality optimization hits

### DIFF
--- a/src/issues/GAS/unsignedComparison.ts
+++ b/src/issues/GAS/unsignedComparison.ts
@@ -4,7 +4,7 @@ const issue: RegexIssue = {
   regexOrAST: 'Regex',
   type: IssueTypes.GAS,
   title: 'Use != 0 instead of > 0 for unsigned integer comparison',
-  regex: /([a-z,A-Z,0-9]*>.?0|0.?<.?[a-z,A-Z,0-9]*)/g,
+  regex: /(?!pragma\s*solidity)[a-z,A-Z,0-9]*>.?0|0.?<.?[a-z,A-Z,0-9]*/g,
 };
 
 export default issue;


### PR DESCRIPTION
Should prevent `pragma solidity >=0.8.7` from showing up as a gas optimization