### PR TITLE
added optional regex precondition check and SafeTransferLib medium for solmate

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -22,6 +22,10 @@ const analyze = (files: InputType, issues: Issue[], githubLink?: string): string
     if (issue.regexOrAST === 'Regex') {
       for (const file of files) {
         const matches: any = [...file.content.matchAll(issue.regex)];
+        if(!!issue.regexPreCondition) {
+          const preConditionMatches: any = [...file.content.matchAll(issue.regexPreCondition)];
+          if (preConditionMatches.length == 0) continue;
+        }
         for (const res of matches) {
           // Filter lines that are comments
           const line = [...res.input?.slice(0, res.index).matchAll(/\n/g)!].length;

--- a/src/issues/M/solmateSafeTransferLib.ts
+++ b/src/issues/M/solmateSafeTransferLib.ts
@@ -1,0 +1,16 @@
+import { IssueTypes, RegexIssue } from '../../types';
+
+const issue: RegexIssue = {
+  regexOrAST: 'Regex',
+  type: IssueTypes.M,
+  title:
+    ' `Solmate\'s SafeTransferLib does not check for token contract\'s existence`',
+  description:
+    'There is a subtle difference between the implementation of solmate’s SafeTransferLib and OZ’s SafeERC20: OZ’s SafeERC20 checks if the token is a contract or not, solmate’s SafeTransferLib does not.\n'
+    + 'https://github.com/transmissions11/solmate/blob/main/src/utils/SafeTransferLib.sol#L9 \n'
+    + '`@dev Note that none of the functions in this library check that a token has code at all! That responsibility is delegated to the caller` \n',
+  regexPreCondition: /solmate\/utils\/SafeTransferLib.sol/g,
+  regex: /.safeTransfer\(|\.safeTransferFrom\(|\.safeApprove\(/g,
+};
+
+export default issue;

--- a/src/issues/M/solmateSafeTransferLib.ts
+++ b/src/issues/M/solmateSafeTransferLib.ts
@@ -4,7 +4,7 @@ const issue: RegexIssue = {
   regexOrAST: 'Regex',
   type: IssueTypes.M,
   title:
-    ' `Solmate\'s SafeTransferLib does not check for token contract\'s existence`',
+    ' Solmate\'s SafeTransferLib does not check for token contract\'s existence',
   description:
     'There is a subtle difference between the implementation of solmate’s SafeTransferLib and OZ’s SafeERC20: OZ’s SafeERC20 checks if the token is a contract or not, solmate’s SafeTransferLib does not.\n'
     + 'https://github.com/transmissions11/solmate/blob/main/src/utils/SafeTransferLib.sol#L9 \n'

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export type RegexIssue = {
   type: IssueTypes;
   title: string;
   regex: RegExp;
+  regexPreCondition?: RegExp;
   impact?: string;
   description?: string;
   startLineModifier?: number; // To build the code snipped from the index of the regex


### PR DESCRIPTION
This PR add's 

1. an optional `regexPreCondition` field for an `RegexIssue` 
2. a new Medium `solmate's SafeTransferLib does not check for token contract's existence`

With the optional regexPreCondition it's possible to filter for specific conditions in a file and later use the normal regex so the correct lines will be added in the report.

Example:

```solidity
// SPDX-License-Identifier: UNLICENSED
pragma solidity 0.8.17;

import {ERC20} from "solmate/tokens/ERC20.sol";
import {SafeTransferLib} from "solmate/utils/SafeTransferLib.sol";

contract CodeCheckExample {
    
    using SafeTransferLib for ERC20;

    function notSoSafeTransfer(address token) external {
        ERC20(token).safeTransfer(address(this), 100);
    }

    function notSoSafeFromTransfer(address token) external {
        ERC20(token).safeTransferFrom(address(this), address(this), 100);
    }

    function notSoSafeApprove(address token) external {
        ERC20(token).safeApprove(address(this), 100);
    }
}
```

Will result in:

## Medium Issues


| |Issue|Instances|
|-|:-|:-:|
| [M-1](#M-1) |  Solmate's SafeTransferLib does not check for token contract's existence | 3 |
### <a name="M-1"></a>[M-1]  Solmate's SafeTransferLib does not check for token contract's existence
There is a subtle difference between the implementation of solmate’s SafeTransferLib and OZ’s SafeERC20: OZ’s SafeERC20 checks if the token is a contract or not, solmate’s SafeTransferLib does not.
https://github.com/transmissions11/solmate/blob/main/src/utils/SafeTransferLib.sol#L9 
`@dev Note that none of the functions in this library check that a token has code at all! That responsibility is delegated to the caller` 


*Instances (3)*:
```solidity
File: src/CheckSolmateAnalyzer.sol

12:         ERC20(token).safeTransfer(address(this), 100);

16:         ERC20(token).safeTransferFrom(address(this), address(this), 100);

20:         ERC20(token).safeApprove(address(this), 100);

```


If there is no import `"solmate/utils/SafeTransferLib.sol";` it will skip safeTransfer, safeTransferFrom and safeApprove as the precondition is not met.