### PR TITLE
Feature unchecked value transfers

### DIFF
--- a/src/issues/M/uncheckedCallValueSuccess.ts
+++ b/src/issues/M/uncheckedCallValueSuccess.ts
@@ -1,0 +1,12 @@
+import { IssueTypes, RegexIssue } from '../../types';
+
+const issue: RegexIssue = {
+  regexOrAST: 'Regex',
+  type: IssueTypes.M,
+  title:
+    'Call.value fallback function reversion risk',
+  description: "Make sure the return boolean of the call function with value is true, otherwise contract risks assuming value has left when not if the fallback function of the destination reverts or is not payable.",
+  regex: /(?<!\(.*,+.*\).*=.*)\.call\{value:/g
+};
+
+export default issue;

--- a/src/issues/M/uncheckedSendSuccess.ts
+++ b/src/issues/M/uncheckedSendSuccess.ts
@@ -1,0 +1,12 @@
+import { IssueTypes, RegexIssue } from '../../types';
+
+const issue: RegexIssue = {
+  regexOrAST: 'Regex',
+  type: IssueTypes.M,
+  title:
+    'Send fallback function reversion risk',
+  description: "Make sure the return boolean of the send function is true, otherwise contract risks assuming value has left when not, if the fallback function of the destination reverts or is not payable.",
+  regex: /(?<!(\.*=.*)|(require.*)|(if.*))\.send\(.*\)/g
+};
+
+export default issue;


### PR DESCRIPTION
Added checks for value transfers which success is not checked:
```solidity
    function sendTest(address payable addr) external {
        (bool b, ) = addr.call{value:1000}(""); //valid if success checked
        (b, ) = addr.call{value:1000}(""); //valid if success checked

        addr.send(2 ether); // invalid

        b = addr.send(2 ether); // valid

        require(addr.send(2 ether));//valid
        require(addr.send(2 ether) && true); //valid

        if (addr.send(2 ether) && true) {} // valid

        addr.call{value:1}(""); //invalid

        revert();
    }
```

I reckon all cases can't be caught (if variable is set but not checked if false) but it would require a more elaborate AST issue which is not in the scope of this exercice.