### PR TITLE
chainlink deprecated function + avoid tx.origin + array indices detec…

### DIFF
--- a/contracts/example/Test.sol
+++ b/contracts/example/Test.sol
@@ -1,7 +1,12 @@
 pragma solidity ^0.8.0;
 
+interface IChainlinkAggregatorV3 {
+    function latestAnswer() external view returns (int256);
+}
+
 contract Test {
     uint256 a = 0;
+    uint256[] b;
 
     function test(address iasd) external returns (uint256) {
         return 123;
@@ -36,5 +41,11 @@ contract Test {
         123/123;
         123/ 123;
         123 /123;
+
+        tx.origin;
+
+        IChainlinkAggregatorV3(msg.sender).latestAnswer();
+
+        b[5];
     }
 }

--- a/src/issues/L/avoidTxOrigin.ts
+++ b/src/issues/L/avoidTxOrigin.ts
@@ -1,0 +1,11 @@
+import {IssueTypes} from "../../types";
+
+const issue = {
+    regexOrAST: 'Regex',
+    type: IssueTypes.L,
+    title: 'Use of `tx.origin` is unsafe in almost every context',
+    description: 'According to [Vitalik Buterin](https://ethereum.stackexchange.com/questions/196/how-do-i-make-my-dapp-serenity-proof), contracts should _not_ `assume that tx.origin will continue to be usable or meaningful`. An example of this is [EIP-3074](https://eips.ethereum.org/EIPS/eip-3074#allowing-txorigin-as-signer-1) which explicitly mentions the intention to change its semantics when it\'s used with new op codes. There have also been calls to [remove](https://github.com/ethereum/solidity/issues/683) `tx.origin`, and there are [security issues](solidity.readthedocs.io/en/v0.4.24/security-considerations.html#tx-origin) associated with using it for authorization. For these reasons, it\'s best to completely avoid the feature.',
+    regex: /tx\.origin/g,
+};
+
+export default issue;

--- a/src/issues/M/deprecatedChainlinkFunction.ts
+++ b/src/issues/M/deprecatedChainlinkFunction.ts
@@ -1,0 +1,11 @@
+import {IssueTypes} from "../../types";
+
+const issue = {
+    regexOrAST: 'Regex',
+    type: IssueTypes.M,
+    title: 'Use of deprecated chainlink function: `latestAnswer()`',
+    description: 'According to Chainlink’s documentation [(API Reference)](https://docs.chain.link/data-feeds/api-reference#latestanswer), the latestAnswer function is deprecated. This function does not throw an error if no answer has been reached, but instead returns 0, possibly causing an incorrect price to be fed to the different price feeds or even a Denial of Service.',
+    regex: /\.latestAnswer\(\)/g
+};
+
+export default issue;

--- a/src/issues/NC/arrayIndices.ts
+++ b/src/issues/NC/arrayIndices.ts
@@ -1,0 +1,25 @@
+import { findAll } from 'solidity-ast/utils';
+import { ASTIssue, InputType, Instance, IssueTypes, RegexIssue } from '../../types';
+import { getStorageVariable, instanceFromSRC } from '../../utils';
+
+const issue: ASTIssue = {
+  regexOrAST: 'AST',
+  type: IssueTypes.NC,
+  title: 'Array indices should be referenced via `enum`s rather than via numeric literals',
+  detector: (files: InputType): Instance[] => {
+    let instances: Instance[] = [];
+
+    for (const file of files) {
+      if (!!file.ast) {
+        for (const indexAccess of findAll('IndexAccess', file.ast)) {
+          if(indexAccess.indexExpression?.nodeType === 'Literal') {
+            instances.push(instanceFromSRC(file, indexAccess.src));
+          }
+        }
+      }
+    }
+    return instances;
+  },
+};
+
+export default issue;


### PR DESCRIPTION
* Chainlink latestAnswer() deprecated function (M)
* Avoid tx.origin (L)
* Use enum instead of literals for array indices (NC) 