### PR TITLE
Add solady's SafeTransferLib detector

### DIFF
--- a/src/issues/M/soladySafeTransferLib.ts
+++ b/src/issues/M/soladySafeTransferLib.ts
@@ -1,0 +1,16 @@
+import { IssueTypes, RegexIssue } from '../../types';
+
+const issue: RegexIssue = {
+  regexOrAST: 'Regex',
+  type: IssueTypes.M,
+  title:
+    'Solady\'s SafeTransferLib does not check for token contract\'s existence',
+  description:
+    'There is a subtle difference between the implementation of solady’s SafeTransferLib and OZ’s SafeERC20: OZ’s SafeERC20 checks if the token is a contract or not, solady’s SafeTransferLib does not.\n'
+    + 'https://github.com/Vectorized/solady/blob/main/src/utils/SafeTransferLib.sol#L10 \n'
+    + '`@dev Note that none of the functions in this library check that a token has code at all! That responsibility is delegated to the caller` \n',
+  regexPreCondition: /solady\/utils\/SafeTransferLib.sol/g,
+  regex: /.safeTransfer\(|\.safeTransferFrom\(|\.safeApprove\(/g,
+};
+
+export default issue;


### PR DESCRIPTION
This is blatantly copied from the [solmate detector](https://github.com/Picodes/4naly3er/blob/main/src/issues/M/solmateSafeTransferLib.ts), just for a similar library.

👇 the test contract used to validate the detection:

```Solidity
pragma solidity >=0.8.20;

import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";

contract VulnerableVault {

    mapping(address owner => mapping (address token => uint256)) balances;

    function deposit(address token, uint256 amount) external {
        SafeTransferLib.safeTransferFrom(token, msg.sender, address(this), amount);
        balances[msg.sender][token] += amount;
    }

    function withdraw(address token, uint256 amount) external {
        balances[msg.sender][token] -= amount;
        SafeTransferLib.safeTransfer(token, msg.sender, amount);
    }
}
```