### PR TITLE
fix "delegateCall in loops" check

### DIFF
--- a/contracts/example/Test.sol
+++ b/contracts/example/Test.sol
@@ -37,4 +37,46 @@ contract Test {
         123/ 123;
         123 /123;
     }
+
+    function test_delegatecall_inloop_1() payable external {
+        uint256 = sum;
+        for(uint i=0; i<10 ; i++) {
+		
+			if(i == 3 ) {
+				continue;
+			}
+			
+			if(i == 5 ) {
+				continue;
+			}
+			// some comment
+            address(this).delegatecall(); // should be reported
+        }
+
+        while(i>0) {
+            i = i-1;
+			
+			if( i == 5) { continue;}
+
+            address(vault).call{value: 0.2}();
+			// come comment
+            address(this).delegatecall(); // should be reported
+        }
+
+        do {
+            address(this).delegatecall();  // should be reported
+            i = i+1;
+        }  while (i < 10) ;
+    }
+
+    function test_delegatecall_inloop_2() payable external {
+        for(uint i=0; i<10 ; i++) {
+		
+			if(i == 3 ) {
+				continue;
+			} // some comment
+
+        } // some comment
+        address(this).delegatecall(); // this shouldn't be reported
+    }
 }

--- a/src/issues/H/delegateCallInLoop.ts
+++ b/src/issues/H/delegateCallInLoop.ts
@@ -5,7 +5,14 @@ const issue: RegexIssue = {
   type: IssueTypes.H,
   title: 'Using `delegatecall` inside a loop',
   impact: 'When calling `delegatecall` the same `msg.value` amount will be accredited multiple times.',
-  regex: /for[^\(]?\([^\)]*\)?.\{((.*[^\}])\n)*.*delegatecall/g,
+  regex: /(for|while|do)[^\(]?(\([^\)]*\))?.?\{(([^\}]*\n)*(([^\}]*\{)([^\{\}]*\n)*([^\{\}]*\}[^\}]*)\n))*[^\}]*delegatecall/g,
+         // (for|while|do)            : detects the loop keyword.             "for"
+         // [^\(]?(\([^\)]*\))?.?\{   : detects loop conditions.              "(....) {"
+         // ([^\}]*\n)*               : detects the line without }.           "......\n"
+         // ([^\}]*\{)                : detects start of the line untile {.   ".......{"
+         // ([^\{\}]*\n)*             : detects the lines without { and }.    "......\n"
+         // ([^\{\}]*\}[^\}]*)\n      : detect the line with }.               "...}..\n"
+         // [^\}]*delegatecall        : detect the lien with delegatecall.    "....call"
 };
 
 export default issue;


### PR DESCRIPTION
The last regex had some issues:
1. it doesn't detected the `while` and `do while` loops. (false negetive)
2. regex only detected `}` when it was in end of the line. (false positive)
3. if lines ended with `\r`, then regex didn't detect the bug properly. (false positive)
4. if there was complete `if() {}` block inside the loop, regex didn't detect the bug. (false negative)
5. if lines didn't end with `\r`, then regex couldn't match the `for () {\n` pattern, because it was forced some character before `\n` always.

the new regex is more complex and there is comments explaining it and it can detects these patterns:
1. detects `for`, `while` and `do while` loops.
2. it can ignore `address.call{value: X}` and `if() {}` inside the loops properly.
3. it will work when lines end with `\n` or `\r\n`

also added 2 test that analyzer should detect 3 instance of the bug in `test_delegatecall_inloop_1()` and it shouldn't report this bug for `test_delegatecall_inloop_2()`.